### PR TITLE
Be able to deploy pyinfra-xdcstore with a one-liner command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,3 @@ XDCGET_CODEBERG_TOKEN   # an API token for the codeberg account
 XDCGET_GITHUB_USER      # the username of a github account
 XDCGET_GITHUB_TOKEN     # an API token for the github account
 ```
-
-**Note:** if you get the following error,
-you just need to re-run the pyinfra command and it works.
-
-```
-    Failed to upload file, retrying: Failure
-    Failed to upload file, retrying: Failure
-    Failed to upload file, retrying: Failure
-    [bomba.testrun.org] Command socket/SSH error: OSError('Failure',)
-    [bomba.testrun.org] Error: executed 2/5 commands
---> pyinfra error: No hosts remaining!
-``` 
-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and [xdcget](https://codeberg.com/webxdc/xdcget).
 To deploy xdcstore and xdcget,
 you need:
 
-- root SSH access to a linux server
+- root SSH access to a linux server (tested with Debian 12)
 - an email account for the bot
 - a github.com and/or codeberg.org account so the bot can download .xdc files from there;
   read more about how to create the neccessary API tokens
@@ -19,7 +19,10 @@ you need:
 
 ## Use it in python code
 
-It can be used from the Python code like this:
+This module can be used
+in a [pyinfra deploy.py](https://docs.pyinfra.com/en/2.x/getting-started.html#create-a-deploy) file
+like this:
+
 ```python
 from pyinfra_xdcstore import deploy_xdcstore
 
@@ -34,9 +37,11 @@ deploy_xdcstore(
 )
 ```
 
-## Deploy with a one-liner
+## Deploy with few CLI commands
 
-It can also be used to deploy xdcstore and xdcget like this:
+You can also use this module
+to deploy xdcstore and xdcget
+with these few CLI commands:
 
 ```
 # install pyinfra, and this module

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ deploy_xdcstore(
 It can also be used to deploy xdcstore and xdcget with an ad-hoc command like this:
 ```
 pip install --user .
-XDCSTORE_EMAIL=xdcstore@example.org XDCSTORE_PASSWORD=p4ssw0rd pyinfra --ssh-user root -- example.org pyinfra_xdcstore.deploy_xdcstore
+XDCSTORE_EMAIL=xdcstore@example.org XDCSTORE_PASSWORD=p4ssw0rd pyinfra --ssh-user root -- bomba.testrun.org pyinfra_xdcstore.one_liner
 ```
 
 Additional environment variables you can use:
 
 ```
+XDCGET_UNIX_USER        # as which user on your server you want the bot to run
 XDCGET_CODEBERG_USER    # the username of a codeberg account
 XDCGET_CODEBERG_TOKEN   # an API token for the codeberg account
 XDCGET_GITHUB_USER      # the username of a github account

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and [xdcget](https://codeberg.com/webxdc/xdcget).
 To deploy xdcstore and xdcget,
 you need:
 
-- SSH access to a linux server
+- root SSH access to a linux server
 - an email account for the bot
 - a github.com and/or codeberg.org account so the bot can download .xdc files from there;
   read more about how to create the neccessary API tokens
@@ -36,16 +36,25 @@ deploy_xdcstore(
 
 ## Deploy with a one-liner
 
-It can also be used to deploy xdcstore and xdcget with an ad-hoc command like this:
+It can also be used to deploy xdcstore and xdcget like this:
+
 ```
+# install pyinfra, and this module
+git clone https://github.com/deltachat/pyinfra-xdcstore
 pip install --user .
-XDCSTORE_EMAIL=xdcstore@example.org XDCSTORE_PASSWORD=p4ssw0rd pyinfra --ssh-user root -- bomba.testrun.org pyinfra_xdcstore.one_liner
+
+# configure the bot's credentials
+export XDCSTORE_EMAIL=xdcstore@example.org
+export XDCSTORE_PASSWORD=p4ssw0rd
+
+# run the deployment
+pyinfra --ssh-user root -- <your_server> deploy.py
 ```
 
-Additional environment variables you can use:
+Additional environment variables you can (and should) use:
 
 ```
-XDCGET_UNIX_USER        # as which user on your server you want the bot to run
+XDCGET_UNIX_USER        # as which user on your server you want the bot to run; default: xdcstore
 XDCGET_CODEBERG_USER    # the username of a codeberg account
 XDCGET_CODEBERG_TOKEN   # an API token for the codeberg account
 XDCGET_GITHUB_USER      # the username of a github account

--- a/README.md
+++ b/README.md
@@ -60,3 +60,16 @@ XDCGET_CODEBERG_TOKEN   # an API token for the codeberg account
 XDCGET_GITHUB_USER      # the username of a github account
 XDCGET_GITHUB_TOKEN     # an API token for the github account
 ```
+
+**Note:** if you get the following error,
+you just need to re-run the pyinfra command and it works.
+
+```
+    Failed to upload file, retrying: Failure
+    Failed to upload file, retrying: Failure
+    Failed to upload file, retrying: Failure
+    [bomba.testrun.org] Command socket/SSH error: OSError('Failure',)
+    [bomba.testrun.org] Error: executed 2/5 commands
+--> pyinfra error: No hosts remaining!
+``` 
+

--- a/deploy.py
+++ b/deploy.py
@@ -49,15 +49,15 @@ def main():
     github_user = os.getenv("XDCGET_GITHUB_USER", "")
     github_token = os.getenv("XDCGET_GITHUB_TOKEN", "")
 
-    error = False
+    required_variables_missing = False
     if bot_email is None:
         pyinfra.logger.error("[error] XDCSTORE_EMAIL can't be empty.")
-        error = True
+        required_variables_missing = True
     if bot_password is None:
         pyinfra.logger.error("[error] XDCSTORE_PASSWORD can't be empty.")
-        error = True
-    if error:
-        return
+        required_variables_missing = True
+    if required_variables_missing:
+        return  # end pyinfra run prematurely
 
     if unix_user not in [user for user in pyinfra.host.get_fact(Users)]:
         create_unix_user(unix_user)

--- a/deploy.py
+++ b/deploy.py
@@ -40,28 +40,32 @@ def create_unix_user(unix_user):
     )
 
 
-unix_user = os.getenv("XDCGET_UNIX_USER", "xdcstore")
-bot_email = os.getenv("XDCSTORE_EMAIL")
-bot_password = os.getenv("XDCSTORE_PASSWORD")
-codeberg_user = os.getenv("XDCGET_CODEBERG_USER", "")
-codeberg_token = os.getenv("XDCGET_CODEBERG_TOKEN", "")
-github_user = os.getenv("XDCGET_GITHUB_USER", "")
-github_token = os.getenv("XDCGET_GITHUB_TOKEN", "")
+def main():
+    unix_user = os.getenv("XDCGET_UNIX_USER", "xdcstore")
+    bot_email = os.getenv("XDCSTORE_EMAIL")
+    bot_password = os.getenv("XDCSTORE_PASSWORD")
+    codeberg_user = os.getenv("XDCGET_CODEBERG_USER", "")
+    codeberg_token = os.getenv("XDCGET_CODEBERG_TOKEN", "")
+    github_user = os.getenv("XDCGET_GITHUB_USER", "")
+    github_token = os.getenv("XDCGET_GITHUB_TOKEN", "")
 
-if bot_email is None:
-    pyinfra.logger.error("XDCSTORE_EMAIL can't be empty.")
-if bot_password is None:
-    pyinfra.logger.error("XDCSTORE_PASSWORD can't be empty.")
+    if bot_email is None:
+        pyinfra.logger.error("XDCSTORE_EMAIL can't be empty.")
+    if bot_password is None:
+        pyinfra.logger.error("XDCSTORE_PASSWORD can't be empty.")
 
-if unix_user not in [user for user in pyinfra.host.get_fact(Users)]:
-    create_unix_user(unix_user)
+    if unix_user not in [user for user in pyinfra.host.get_fact(Users)]:
+        create_unix_user(unix_user)
 
-deploy_xdcstore(
-    unix_user,
-    bot_email,
-    bot_password,
-    codeberg_user=codeberg_user,
-    codeberg_token=codeberg_token,
-    github_user=github_user,
-    github_token=github_token,
-)
+    deploy_xdcstore(
+        unix_user,
+        bot_email,
+        bot_password,
+        codeberg_user=codeberg_user,
+        codeberg_token=codeberg_token,
+        github_user=github_user,
+        github_token=github_token,
+    )
+
+
+main()

--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,28 @@
+import os
+
+import pyinfra
+
+from pyinfra_xdcstore import deploy_xdcstore
+
+unix_user = os.getenv("XDCGET_UNIX_USER", "xdcstore")
+bot_email = os.getenv("XDCSTORE_EMAIL")
+bot_password = os.getenv("XDCSTORE_PASSWORD")
+codeberg_user = os.getenv("XDCGET_CODEBERG_USER", "")
+codeberg_token = os.getenv("XDCGET_CODEBERG_TOKEN", "")
+github_user = os.getenv("XDCGET_GITHUB_USER", "")
+github_token = os.getenv("XDCGET_GITHUB_TOKEN", "")
+
+if bot_email is None:
+    pyinfra.logger.error("XDCSTORE_EMAIL can't be empty.")
+if bot_password is None:
+    pyinfra.logger.error("XDCSTORE_PASSWORD can't be empty.")
+
+deploy_xdcstore(
+    unix_user,
+    bot_email,
+    bot_password,
+    codeberg_user=codeberg_user,
+    codeberg_token=codeberg_token,
+    github_user=github_user,
+    github_token=github_token,
+)

--- a/deploy.py
+++ b/deploy.py
@@ -1,6 +1,7 @@
 import os
 
 import pyinfra
+from pyinfra.facts.server import Users
 
 from pyinfra_xdcstore import deploy_xdcstore
 
@@ -16,6 +17,9 @@ if bot_email is None:
     pyinfra.logger.error("XDCSTORE_EMAIL can't be empty.")
 if bot_password is None:
     pyinfra.logger.error("XDCSTORE_PASSWORD can't be empty.")
+
+if unix_user not in [user for user in pyinfra.host.get_fact(Users)]:
+    pyinfra.logger.error(f"{unix_user} doesn't exist on the server; create it or choose an existing user with XDCGET_UNIX_USER")
 
 deploy_xdcstore(
     unix_user,

--- a/deploy.py
+++ b/deploy.py
@@ -1,3 +1,8 @@
+"""
+This is an example pyinfra deploy file for installing xdcstore and xdcget.
+Its usage is documented in https://github.com/deltachat/pyinfra-xdcstore/#deploy-with-few-cli-commands
+"""
+
 import os
 import importlib
 

--- a/deploy.py
+++ b/deploy.py
@@ -49,10 +49,15 @@ def main():
     github_user = os.getenv("XDCGET_GITHUB_USER", "")
     github_token = os.getenv("XDCGET_GITHUB_TOKEN", "")
 
+    error = False
     if bot_email is None:
-        pyinfra.logger.error("XDCSTORE_EMAIL can't be empty.")
+        pyinfra.logger.error("[error] XDCSTORE_EMAIL can't be empty.")
+        error = True
     if bot_password is None:
-        pyinfra.logger.error("XDCSTORE_PASSWORD can't be empty.")
+        pyinfra.logger.error("[error] XDCSTORE_PASSWORD can't be empty.")
+        error = True
+    if error:
+        return
 
     if unix_user not in [user for user in pyinfra.host.get_fact(Users)]:
         create_unix_user(unix_user)

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -34,7 +34,7 @@ def deploy_xdcstore(
 
     if clone_xdcget.changed:
         server.script(
-            name=f"Setup virtual environment for xdcget",
+            name="Setup virtual environment for xdcget",
             src=importlib.resources.files(__package__).joinpath("setup-venv.sh"),
             _su_user=unix_user,
             _use_su_login=True,
@@ -42,7 +42,9 @@ def deploy_xdcstore(
 
         server.shell(
             name="Compile xdcget",
-            commands=[f". .local/lib/xdcget.venv/bin/activate && cd /home/{unix_user}/xdcget && pip install ."],
+            commands=[
+                f". .local/lib/xdcget.venv/bin/activate && cd /home/{unix_user}/xdcget && pip install ."
+            ],
             _su_user=unix_user,
             _use_su_login=True,
         )

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -27,8 +27,8 @@ def deploy_xdcstore(
     """
 
     clone_xdcget = git.repo(
-        name=f"Pull the xdcget repository",
-        src=f"https://codeberg.org/webxdc/xdcget",
+        name="Pull the xdcget repository",
+        src="https://codeberg.org/webxdc/xdcget",
         dest=f"/home/{unix_user}/xdcget",
         _su_user=unix_user,
         _use_su_login=True,
@@ -53,7 +53,7 @@ def deploy_xdcstore(
     ]
     env = "\n".join(secrets)
     files.put(
-        name=f"upload secrets",
+        name="upload secrets",
         src=StringIO(env),
         dest=f"/home/{unix_user}/.env",
         mode="0600",
@@ -76,7 +76,7 @@ def deploy_xdcstore(
     )
 
     files.put(
-        name=f"upload xstore-update.sh",
+        name="upload xstore-update.sh",
         src=importlib.resources.files(__package__).joinpath("xstore-update.sh"),
         dest=f"/home/{unix_user}/.config/systemd/user/",
         user=unix_user,
@@ -84,7 +84,7 @@ def deploy_xdcstore(
     )
 
     files.template(
-        name=f"upload xstore-update systemd unit",
+        name="upload xstore-update systemd unit",
         src=importlib.resources.files(__package__).joinpath("xstore-update.service.j2"),
         dest=f"/home/{unix_user}/.config/systemd/user/xstore-update.service",
         user=unix_user,
@@ -92,7 +92,7 @@ def deploy_xdcstore(
         bot_email=bot_email,
     )
     systemd.service(
-        name=f"reload and restart xstore-update systemd service",
+        name="reload and restart xstore-update systemd service",
         service="xstore-update.service",
         user_name=unix_user,
         user_mode=True,
@@ -105,7 +105,7 @@ def deploy_xdcstore(
     )
 
     files.template(
-        name=f"upload xstore systemd unit",
+        name="upload xstore systemd unit",
         src=importlib.resources.files(__package__).joinpath("xstore.service.j2"),
         dest=f"/home/{unix_user}/.config/systemd/user/xstore.service",
         user=unix_user,

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -1,8 +1,6 @@
 import importlib.resources
-import os
 from io import StringIO
 
-import pyinfra
 from pyinfra.operations import files, systemd, server, git
 
 

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -6,13 +6,15 @@ import pyinfra
 from pyinfra.operations import files, systemd, server, git
 
 
-def deploy_xdcstore(unix_user: str,
-                    bot_email: str,
-                    bot_passwd: str,
-                    codeberg_user="",
-                    codeberg_token="",
-                    github_user="",
-                    github_token=""):
+def deploy_xdcstore(
+    unix_user: str,
+    bot_email: str,
+    bot_passwd: str,
+    codeberg_user="",
+    codeberg_token="",
+    github_user="",
+    github_token="",
+):
     """Deploy xdcstore and xdcget to a UNIX user.
 
     :param unix_user: the existing UNIX user of the bot
@@ -124,7 +126,7 @@ def deploy_xdcstore(unix_user: str,
     )
 
 
-if __name__ == "__main__":
+def one_liner():
     unix_user = os.getenv("XDCGET_UNIX_USER", "xdcstore")
     bot_email = os.getenv("XDCSTORE_EMAIL")
     bot_password = os.getenv("XDCSTORE_PASSWORD")

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -74,7 +74,7 @@ def deploy_xdcstore(
     )
 
     files.put(
-        name="upload xstore-update.sh",
+        name="upload xstore-update.sh - usually fails on the first try, just re-run the command",
         src=importlib.resources.files(__package__).joinpath("xstore-update.sh"),
         dest=f"/home/{unix_user}/.config/systemd/user/",
         user=unix_user,

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -83,7 +83,7 @@ def deploy_xdcstore(
     files.put(
         name="upload xstore-update.sh - usually fails on the first try, just re-run the command",
         src=importlib.resources.files(__package__).joinpath("xstore-update.sh"),
-        dest=f"/home/{unix_user}/.config/systemd/user/",
+        dest=f"/home/{unix_user}/.local/lib/xdcget.venv/bin/xstore-update.sh",
         user=unix_user,
         mode="0700",
     )

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -35,7 +35,7 @@ def deploy_xdcstore(
     if clone_xdcget.changed:
         server.shell(
             name="Compile xdcget",
-            commands=[f"cd /home/{unix_user}/xdcget && pip install --user ."],
+            commands=[f"cd /home/{unix_user}/xdcget && pip install --break-system-packages --user ."],
             _su_user=unix_user,
             _use_su_login=True,
         )

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -81,7 +81,7 @@ def deploy_xdcstore(
     )
 
     files.put(
-        name="upload xstore-update.sh - usually fails on the first try, just re-run the command",
+        name="upload xstore-update.sh",
         src=importlib.resources.files(__package__).joinpath("xstore-update.sh"),
         dest=f"/home/{unix_user}/.local/lib/xdcget.venv/bin/xstore-update.sh",
         user=unix_user,

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -33,9 +33,16 @@ def deploy_xdcstore(
     )
 
     if clone_xdcget.changed:
+        server.script(
+            name=f"Setup virtual environment for xdcget",
+            src=importlib.resources.files(__package__).joinpath("setup-venv.sh"),
+            _su_user=unix_user,
+            _use_su_login=True,
+        )
+
         server.shell(
             name="Compile xdcget",
-            commands=[f"cd /home/{unix_user}/xdcget && pip install --break-system-packages --user ."],
+            commands=[f". .local/lib/xdcget.venv/bin/activate && cd /home/{unix_user}/xdcget && pip install ."],
             _su_user=unix_user,
             _use_su_login=True,
         )

--- a/pyinfra_xdcstore/__init__.py
+++ b/pyinfra_xdcstore/__init__.py
@@ -124,28 +124,3 @@ def deploy_xdcstore(
         _su_user=unix_user,
         _use_su_login=True,
     )
-
-
-def one_liner():
-    unix_user = os.getenv("XDCGET_UNIX_USER", "xdcstore")
-    bot_email = os.getenv("XDCSTORE_EMAIL")
-    bot_password = os.getenv("XDCSTORE_PASSWORD")
-    codeberg_user = os.getenv("XDCGET_CODEBERG_USER", "")
-    codeberg_token = os.getenv("XDCGET_CODEBERG_TOKEN", "")
-    github_user = os.getenv("XDCGET_GITHUB_USER", "")
-    github_token = os.getenv("XDCGET_GITHUB_TOKEN", "")
-
-    if bot_email is None:
-        pyinfra.logger.error("XDCSTORE_EMAIL can't be empty.")
-    if bot_password is None:
-        pyinfra.logger.error("XDCSTORE_PASSWORD can't be empty.")
-
-    deploy_xdcstore(
-        unix_user,
-        bot_email,
-        bot_password,
-        codeberg_user=codeberg_user,
-        codeberg_token=codeberg_token,
-        github_user=github_user,
-        github_token=github_token,
-    )

--- a/pyinfra_xdcstore/setup-venv.sh
+++ b/pyinfra_xdcstore/setup-venv.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+python3 -m venv ~/.local/lib/xdcget.venv
+source ~/.local/lib/xdcget.venv/bin/activate
+pip install -U pip wheel

--- a/pyinfra_xdcstore/xstore-update.service.j2
+++ b/pyinfra_xdcstore/xstore-update.service.j2
@@ -2,7 +2,7 @@
 Description=update xdcstore and xdcget every 15 minutes: {{ bot_email }}
 
 [Service]
-ExecStart=/home/{{ unix_user }}/.config/systemd/user/xstore-update.sh
+ExecStart=/home/{{ unix_user }}/.local/lib/xdcget.venv/bin/xstore-update.sh
 EnvironmentFile=/home/{{ unix_user }}/.env
 WorkingDirectory=/home/{{ unix_user }}
 Restart=always

--- a/pyinfra_xdcstore/xstore-update.sh
+++ b/pyinfra_xdcstore/xstore-update.sh
@@ -4,11 +4,12 @@ trap "systemctl --user start xstore.service" EXIT
 
 set -e
 
+. $HOME/.local/lib/xdcget.venv/bin/activate
 cd xdcget
 git pull --autostash --rebase origin main
-pip install --break-system-packages --user .
+pip install .
 
-$HOME/.local/bin/xdcget update
+$HOME/.local/lib/xdcget.venv/bin/xdcget update
 
 cd ..
 wget https://download.delta.chat/store/preview/xdcstore-main.tar.gz

--- a/pyinfra_xdcstore/xstore-update.sh
+++ b/pyinfra_xdcstore/xstore-update.sh
@@ -6,7 +6,7 @@ set -e
 
 cd xdcget
 git pull --autostash --rebase origin main
-pip install --user .
+pip install --break-system-packages --user .
 
 $HOME/.local/bin/xdcget update
 

--- a/pyinfra_xdcstore/xstore.profile
+++ b/pyinfra_xdcstore/xstore.profile
@@ -1,0 +1,6 @@
+export XDG_RUNTIME_DIR="/run/user/$UID"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm if it exists
+[ -s "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"  # This loads the cargo environment if it exists
+export PATH=$PATH:$HOME/.local/bin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyinfra-xdcstore"
 version = "0.1"
+
+[tool.ruff]
+line-length = 121

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[metadata]
+name = pyinfra_xdcstore
+version = 0.0.1
+author = missytake
+author_email = missytake@systemli.org
+description = A pyinfra module for deploying xdcstore and xdcget.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/deltachat/pyinfra-xdcstore
+project_urls =
+    Bug Tracker = https://github.com/deltachat/pyinfra-xdcstore/issues
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: ISC License (ISCL)
+    Operating System :: OS Independent
+
+[options]
+package_dir =
+    = pyinfra_xdcstore
+packages = find:
+python_requires = >=3.8
+install_requires =
+    pyinfra
+
+[options.packages.find]
+where = pyinfra_xdcstore
+
+[tox:tox]
+envlist = lint, py310
+isolated_build = True
+
+[testenv:lint]
+skip_install = True
+deps =
+    black
+    flake8
+commands =
+    black --check --diff src tests
+    flake8 src tests
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest tests
+
+[flake8]
+max_line_length = 121


### PR DESCRIPTION
The goal is that users don't need to write their own deploy.py file and can just run xdcstore with some commands from the README.md.